### PR TITLE
Add syntax element :placeholder:

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -213,6 +213,15 @@ h1, .md-header__title, .md-typeset .admonition-title, .md-typeset details summar
     border-radius: 4px;
 	font-style: italic;
 }
+.md-typeset .typo-placeholder {
+    display: inline-block;
+    border: 1px solid var(--md-accent-fg-color);
+	border-style: dashed;
+    padding: 0 2px;
+	margin: 0 2px;
+    border-radius: 4px;
+	font-style: italic;
+}
 
 
 /* External links */

--- a/docs/tutorial/event.md
+++ b/docs/tutorial/event.md
@@ -127,7 +127,7 @@ This is important because changing these settings after already having received 
 
 Switching to the "Shop design" tab at the top allows us to add images to our event shop and customize its colors. 
 Clicking the :btn-icon:fontawesome-regular-eye:Go to shop: button in the bar at the top takes us to a preview of the shop from the customers' perspective. 
-A shop created with pretix Hosted will by default be located at https://pretix.eu/[OrganizerShortForm]/[EventShortForm]/. 
+A shop created with pretix Hosted will by default be located at https://pretix.eu/:placeholder:OrganizerShortForm:/:placeholder:EventShortForm:/. 
 The shop we are creating for this tutorial is located at [https://pretix.eu/tut/tutcon27/](https://pretix.eu/tut/tutcon27/). 
 
 By default, the name of the event will be displayed in the page header of our shop. 

--- a/docs/tutorial/organizer-account.md
+++ b/docs/tutorial/organizer-account.md
@@ -91,7 +91,7 @@ We use the :btn:Save: button to apply our localization settings __before__ chang
 Switching to the :btn:Organizer page: tab at the top allows us to add our logo and customize our shop's interface colors.
 
 Clicking the :btn-icon:fontawesome-regular-eye:Public profile: button in the bar at the top takes us to a preview of the organizer page from the customers' perspective.
-An organizer page created with pretix Hosted will by default be located at https://pretix.eu/[OrganizerShortForm]/.
+An organizer page created with pretix Hosted will by default be located at https://pretix.eu/:placeholder:OrganizerShortForm:/.
 The shop we are creating for this tutorial is located at [https://pretix.eu/tut/](https://pretix.eu/tut).
 
 By default, the name of the organizer will be displayed in the page header of our page.

--- a/overrides/hooks/custommarkup.py
+++ b/overrides/hooks/custommarkup.py
@@ -25,6 +25,13 @@ def on_page_markdown(
         )
         return f'<span class="typo-navlayer">{match.group(1)}</span>'
 
+    def replace_placeholder(match: Match):
+        return f'<span class="typo-placeholder">{match.group(1)}</span>'
+
+    markdown = re.sub(
+        r":placeholder:([^:]*):",
+        replace_placeholder, markdown, flags = re.I
+    )
     markdown = re.sub(
         r":btn:([^:]+):",
         replace_btn, markdown, flags = re.I


### PR DESCRIPTION
I opted for slightly different styling than in the navpaths. With the same styling as the navpaths, it was too hard to read the / in between the placeholders because they were to dominant.

![image](https://github.com/user-attachments/assets/7ebfba83-68a7-4e92-b2ad-c501ef009aab)
