### PR TITLE
Fix alphabetical sorting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ plugins:
   - awesome-pages:
       order: asc
       sort_type: natural
+      ignore_case: true
       order_by: title
   - glightbox
   - macros:


### PR DESCRIPTION
mkdocs.yml add `ignore_case: true`to plugins: - awesome-pages:. 
Case is now ignored when sorting articles alphabetically 